### PR TITLE
feat #83 #95

### DIFF
--- a/backend/src/channels/channels.resolver.ts
+++ b/backend/src/channels/channels.resolver.ts
@@ -95,6 +95,7 @@ export class ChannelsResolver {
   async muteUserOnChannel(
     @UserID() my_id: string,
     @Args('user_id', { type: () => ID! }) user_id: string,
+    @Args('mute_time', { type: () => Int! }) mute_time: number,
   ): Promise<boolean> {
     // Mute myself?
     if (my_id === user_id) {
@@ -112,7 +113,16 @@ export class ChannelsResolver {
     }
 
     const channel_id = await this.usersService.getChannelIdByUserId(my_id);
-    await this.channelsService.updateChannelMute(channel_id, user_id, true);
+    if (channel_id === null) {
+      throw new ConflictException(
+        `The user(id: ${my_id}) is not on any channel`,
+      );
+    }
+    await this.channelsService.updateChannelMute(
+      channel_id,
+      user_id,
+      mute_time,
+    );
     return true;
   }
 
@@ -123,7 +133,12 @@ export class ChannelsResolver {
     @Args('user_id', { type: () => ID! }) user_id: string,
   ): Promise<boolean> {
     const channel_id = await this.usersService.getChannelIdByUserId(my_id);
-    await this.channelsService.updateChannelMute(channel_id, user_id, false);
+    if (channel_id === null) {
+      throw new ConflictException(
+        `The user(id: ${my_id}) is not on any channel`,
+      );
+    }
+    await this.channelsService.updateChannelMute(channel_id, user_id, 0);
     return true;
   }
 

--- a/backend/src/channels/channels.service.ts
+++ b/backend/src/channels/channels.service.ts
@@ -399,7 +399,8 @@ export class ChannelsService {
   }
 
   async updateChannelRole(user_id: string, role: UserRole): Promise<boolean> {
-    const updateChannel = await this.databaseService.executeQuery(`
+    const updateChannel: { channel_id: string }[] = await this.databaseService
+      .executeQuery(`
       UPDATE
         ${schema}.channel_user
       SET
@@ -415,6 +416,14 @@ export class ChannelsService {
         `The user(id: ${user_id}) is not on any channel`,
       );
     } else {
+      this.pubSub.publish(`to_channel_${updateChannel[0].channel_id}`, {
+        subscribeChannel: {
+          type: Notify.TRANSFER,
+          participant: await this.usersService.getUserById(user_id),
+          text: role,
+          check: true,
+        },
+      });
       return true;
     }
   }

--- a/backend/src/channels/channels.service.ts
+++ b/backend/src/channels/channels.service.ts
@@ -312,18 +312,28 @@ export class ChannelsService {
   async updateChannelMute(
     channel_id: string,
     user_id: string,
-    mute: boolean,
+    mute_time: number,
   ): Promise<void> {
-    if (this.muted_users.hasUser(channel_id, user_id) === mute) {
+    // Check the channel exists
+    if (this.muted_users.hasChannel(channel_id) === false) {
+      // Do nothing
+      return;
+    }
+
+    // Check the user in muted list
+    if (this.muted_users.hasUser(channel_id, user_id) === !!mute_time) {
       throw new ConflictException(
         `The user(id: ${user_id}) is already ${
-          mute ? 'muted' : 'unmuted'
+          mute_time ? 'muted' : 'unmuted'
         } in this channel(id: ${channel_id})`,
       );
     }
 
-    if (mute) {
+    if (mute_time) {
       this.muted_users.pushUser(channel_id, user_id);
+      setTimeout(() => {
+        this.updateChannelMute(channel_id, user_id, 0);
+      }, mute_time);
     } else {
       this.muted_users.popUser(channel_id, user_id);
     }
@@ -333,7 +343,7 @@ export class ChannelsService {
         type: Notify.MUTE,
         participant: this.usersService.getUserById(user_id),
         text: null,
-        check: mute,
+        check: !!mute_time,
       },
     });
   }

--- a/backend/src/channels/models/channel.model.ts
+++ b/backend/src/channels/models/channel.model.ts
@@ -9,6 +9,7 @@ export enum Notify {
   BAN = 'BAN',
   EDIT = 'EDIT',
   DELETE = 'DELETE',
+  TRANSFER = 'TRANSFER',
 }
 
 registerEnumType(Notify, {


### PR DESCRIPTION
- #83
  - Notify에 TRANSFER을 추가하고
  - 권한이 변경될 때마다 아래 내용을 publish 하도록 했습니다
    - `type: Notify.TRANSFER`
    - `participant: 변경된 유저`
    - `text: 변경된 유저 권한`
    - `check: true`
- #95 
  - `muteUserOnChannel` 뮤테이션에 `mute_time` 인자를 다시 추가하고 `mute_time` 초가 지나면 unmute되도록 수정했습니다