### PR TITLE
fix: No channel in muted_users is not an error

### DIFF
--- a/backend/src/channels/channels.service.ts
+++ b/backend/src/channels/channels.service.ts
@@ -313,7 +313,7 @@ export class ChannelsService {
     // Check the validate of channel_id and user_id
     if (
       this.muted_users.hasChannel(channel_id) === false ||
-      this.muted_users.hasUser(channel_id, user_id)
+      this.muted_users.hasUser(channel_id, user_id) === false
     ) {
       // Do nothing
       return;

--- a/backend/src/channels/classes/mutedusers.class.ts
+++ b/backend/src/channels/classes/mutedusers.class.ts
@@ -32,14 +32,13 @@ export class MutedUsers {
     user_id: string,
     push: boolean,
   ): boolean {
+    if (this.channels.get(channel_id) === undefined) {
+      this.updateChannel(channel_id, true);
+    }
+
     const usersSet = this.channels.get(channel_id);
 
-    if (usersSet === undefined) {
-      console.error(`User pushed before channel(id: ${channel_id}) push`);
-      throw new InternalServerErrorException(
-        `No such channel(id: ${channel_id})`,
-      );
-    } else if (!!usersSet.has(user_id) === push) {
+    if (!!usersSet.has(user_id) === push) {
       // Already muted or unmuted
       return false;
     } else {


### PR DESCRIPTION
- `muted_users` 에 해당하는 `channel_id` 가 없을 경우 에러를 발생시키지 않고 새로운 Set을 set하도록 변경했습니다
- `muteTimeoutHandler` 에서 `user_id` 의 validate를 잘못 확인하는 버그를 수정했습니다