### PR TITLE
fix: #95 #116

### DIFF
--- a/backend/src/channels/channels.service.ts
+++ b/backend/src/channels/channels.service.ts
@@ -232,7 +232,7 @@ export class ChannelsService {
         password
       ) = (
         '${title}',
-        '${password ? `${await this.hashPassword(password)}` : 'NULL'}'
+        ${password ? `'${await this.hashPassword(password)}'` : 'NULL'}
       )
       WHERE
         id = ${channel_id}
@@ -319,6 +319,14 @@ export class ChannelsService {
       return;
     } else {
       this.muted_users.popUser(channel_id, user_id);
+      this.pubSub.publish(`to_channel_${channel_id}`, {
+        subscribeChannel: {
+          type: Notify.MUTE,
+          participant: this.usersService.getUserById(user_id),
+          text: null,
+          check: false,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
# 수정 사항
- 뮤트 풀리면 publish 하는 기능
- 채널 수정에 비밀번호를 null로 보낼 때 NULL 패스워드를 저장하던 버그 수정

# 테스트
프론트엔드에서
- 뮤트가 풀리는 기능과
- 비밀번호 없이 방을 수정할 때 public으로 전환되는 것 확인했습니다