### PR TITLE
feature/#144/status

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Post,
   Query,
+  ConflictException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { Request, Response } from 'express';
@@ -15,11 +16,15 @@ import { env } from 'src/utils/envs';
 import { UsersService } from 'src/users/users.service';
 import { PassTfaGuard } from './decorators/pass-tfa-guard.decorator';
 import { PassLoginGuard } from './decorators/pass-login-guard.decorator';
+import { StatusService } from 'src/status/status.service';
+import { UserStatus } from 'src/users/models/user.model';
+import { UserID } from 'src/users/decorators/user-id.decorator';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
+    private readonly statusService: StatusService,
     private readonly usersService: UsersService, // FIXME: remove this
   ) {}
 
@@ -35,6 +40,14 @@ export class AuthController {
   @PassTfaGuard()
   @PassLoginGuard()
   async loginWithFortyTwo(@Req() req: any, @Res() res: Response) {
+    const my_status = await this.statusService.getStatus(req.user.id);
+    if (my_status !== UserStatus.OFFLINE) {
+      req.session.destroy();
+      throw new ConflictException(
+        `The user(id: ${req.user.id}) is already logged in.`,
+      );
+    }
+
     const tfa_secret = await this.usersService.getSecret(req.user.id);
 
     req.session.uid = req.user.id;
@@ -88,10 +101,11 @@ export class AuthController {
   }
 
   @Get('logout')
-  async logout(@Req() req: any, @Res() res: Response) {
-    res.cookie[env.session.cookieName] = '';
+  async logout(@UserID() userId, @Req() req: any, @Res() res: Response) {
+    await this.statusService.deleteConnection(undefined, userId);
+    req.session.destroy();
+    res.clearCookie(env.session.cookieName);
     res.redirect('/');
-    // Delete session in statusService.deleteConnection that called from onDisconnect()
   }
 
   @Get('test')

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,9 +6,10 @@ import { AuthService } from './auth.service';
 import { FTStrategy } from './strategies/ft.strategy';
 import { AuthResolver } from './auth.resolver';
 import { DatabaseModule } from 'src/database/database.module';
+import { StatusModule } from 'src/status/status.module';
 
 @Module({
-  imports: [UsersModule, DatabaseModule, PassportModule],
+  imports: [UsersModule, DatabaseModule, PassportModule, StatusModule],
   controllers: [AuthController],
   providers: [AuthService, FTStrategy, AuthResolver],
 })

--- a/backend/src/status/status.service.ts
+++ b/backend/src/status/status.service.ts
@@ -42,8 +42,13 @@ export class StatusService {
     return this.statusContainer.get(userId)?.status ?? UserStatus.OFFLINE;
   }
 
-  newConnection(webSocketKey: string, userId: string, sid: string): void {
-    if (this.statusContainer.has(userId)) this.deleteConnection(webSocketKey);
+  async newConnection(
+    webSocketKey: string,
+    userId: string,
+    sid: string,
+  ): Promise<void> {
+    if (this.statusContainer.has(userId))
+      await this.deleteConnection(webSocketKey, userId);
     this.pubSub.publish(`status_of_${userId}`, {
       statusChange: UserStatus.ONLINE,
     });
@@ -54,14 +59,15 @@ export class StatusService {
     this.webSocketKeyContainer.set(webSocketKey, { userId });
   }
 
-  deleteConnection(webSocketKey: string): void {
-    const userId = this.webSocketKeyContainer.get(webSocketKey)?.userId;
+  async deleteConnection(webSocketKey: string, userId: string): Promise<void> {
+    if (!userId) userId = this.webSocketKeyContainer.get(webSocketKey)?.userId;
     if (!userId) return;
     const statusObject = this.statusContainer.get(userId);
+    if (!statusObject) return;
 
-    this.gamesService.surrenderGameWithUserId(user_id);
-    this.databaseService.executeQuery(
-      `DELETE FROM ${env.database.schema}.user_session WHERE sid = '${statusObject.sid}';`,
+    this.gamesService.surrenderGameWithUserId(userId);
+    await this.databaseService.executeQuery(
+      `DELETE FROM ${env.database.schema}.user_session WHERE sid = '${statusObject.sid}' RETURNING sid;`,
     );
     this.webSocketKeyContainer.delete(webSocketKey);
     this.statusContainer.delete(userId);

--- a/backend/src/utils/factories/graphql.factory.ts
+++ b/backend/src/utils/factories/graphql.factory.ts
@@ -37,7 +37,7 @@ export function graphqlFactory(statusService: StatusService) {
             cookies[env.session.cookieName],
             env.session.secret,
           );
-          if (sid === false) throw new WsException('Invalid credentials.');
+          if (!sid) throw new WsException('Invalid credentials.');
           else
             sessionStore.createSession(
               webSocket.upgradeReq,
@@ -46,13 +46,14 @@ export function graphqlFactory(statusService: StatusService) {
           statusService.newConnection(
             webSocket.upgradeReq.headers['sec-websocket-key'],
             webSocket.upgradeReq.session.uid,
-            webSocket.upgradeReq.session.id,
+            sid,
           );
           return { req: webSocket.upgradeReq };
         },
-        onDisconnect: (webSocket, context) => {
-          statusService.deleteConnection(
+        onDisconnect: async (webSocket, context) => {
+          await statusService.deleteConnection(
             webSocket.upgradeReq.headers['sec-websocket-key'],
+            undefined,
           );
         },
       },


### PR DESCRIPTION
이미 로그인 된 계정으로 중복로그인 시도시 409 Conflict 에러가 발생하도록 했고,
로그아웃하거나 소켓 연결이 끊길 경우 (창이 닫힐 때) status를 Offline으로 변경하도록 했습니다
`getStatus` 로 유저의 상태를 쿼리할 수 있고 `statusChange` 로 유저의 상태를 subscribe 할 수 있습니다

- #149
  - 위 기능을 추가한 후 Dummy 로그인은 로그아웃되지 않는 문제가 있습니다. 새로고침하면 로그인 화면으로 돌아가긴하는데 원인을 모르겠습니다
